### PR TITLE
Update integer.py to parse integers in exp notation

### DIFF
--- a/gfapy/field/integer.py
+++ b/gfapy/field/integer.py
@@ -3,7 +3,7 @@ import re
 
 def decode(string):
   try:
-    return int(string)
+    return int(float(string))
   except:
     raise gfapy.FormatError("the string does not represent a valid integer")
 


### PR DESCRIPTION
When integer value is given in exponential notation, python doesn't parse it as an integer resulting in not validating the `gfa` file. Casting to `float` and then to `int` resolves the issue.