### PR TITLE
use raw strings for regex

### DIFF
--- a/gfapy/field/float.py
+++ b/gfapy/field/float.py
@@ -17,7 +17,7 @@ def validate_encoded(string):
   if not re.match(r"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$", string):
     raise gfapy.FormatError(
       "{} does not represent a valid float\n".format(repr(string)) +
-      "(it does not match [-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)")
+      r"(it does not match [-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)")
 
 def unsafe_encode(obj):
   return str(obj)


### PR DESCRIPTION
This addresses some SyntaxWarning found by Debian checks, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085607.