### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,41 @@
+name: run-test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python # Set Python version
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install gfapy
+        run: |
+          pip install .
+      # Install pip and pytest
+      - name: Install pytest
+        run: |
+          #python -m pip install --upgrade pip
+          pip install pytest pytest-dependency
+      - name: Test with pytest
+        run: pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python # Set Python version
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: run-test
 
 on:
   push:
-    branches: [master, CI]
+    branches: [master]
   pull_request:
-    branches: [master, CI]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: run-test
 
 on:
   push:
-    branches: [master]
+    branches: [master, CI]
   pull_request:
-    branches: [master]
+    branches: [master, CI]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Test with pytest
         run: pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/tests/test_api_rgfa.py
+++ b/tests/test_api_rgfa.py
@@ -25,8 +25,8 @@ class TestAPIrGfa(unittest.TestCase):
 
   def test_stable_sequence_names(self):
     g = gfapy.Gfa.from_file("tests/testdata/rgfa_example.2.gfa", dialect="rgfa")
-    self.assertEqual(['smpl-Ref.Bd4', 'smpl-Bd21_3_r.pseudomolecule_4'],
-        g.stable_sequence_names)
+    self.assertEqual(sorted(['smpl-Ref.Bd4', 'smpl-Bd21_3_r.pseudomolecule_4']),
+        sorted(g.stable_sequence_names))
     g = gfapy.Gfa.from_file("tests/testdata/rgfa_example.1.gfa", dialect="rgfa")
-    self.assertEqual(['bar', 'foo', 'chr1'],
-        g.stable_sequence_names)
+    self.assertEqual(sorted(['bar', 'foo', 'chr1']),
+        sorted(g.stable_sequence_names))


### PR DESCRIPTION
Played around a bit with a GitHub Actions CI pipeline for pytest I have working in another repo.
One test in test_api_rgfa.py was failing because of different ordering in the lists, fixed that by sorting before the comparison (I figured the ordering isn't critical, and everything else is passing anyway).
CI [is passing now](https://github.com/lrauschning/gfapy/actions/runs/19275508760) :-)
Cheers,
Leon
